### PR TITLE
Enable DozeService (Ambient Display) for falcon

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -243,7 +243,6 @@
     <bool name="config_enableMultiUserUI">true</bool>
     
     <!-- Enable Doze Service -->
-
     <bool name="doze_display_state_supported">true</bool>
     <string name="config_dozeComponent">com.android.systemui/com.android.systemui.doze.DozeService</string>
     <bool name="config_dozeAfterScreenOff">true</bool>

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -241,5 +241,15 @@
 
     <!-- Whether UI for multi user should be shown -->
     <bool name="config_enableMultiUserUI">true</bool>
+    
+    <!-- Enable Doze Service -->
+
+    <bool name="doze_display_state_supported">true</bool>
+    <string name="config_dozeComponent">com.android.systemui/com.android.systemui.doze.DozeService</string>
+    <bool name="config_dozeAfterScreenOff">true</bool>
+    <bool name="config_powerDecoupleInteractiveModeFromDisplay">true</bool>
+    
+    <!-- Screen brightness when dozing. -->
+    <integer name="config_screenBrightnessDoze">17</integer>
 
 </resources>


### PR DESCRIPTION
This feature was present in original Motorola 5.0 firmware. However, still missing in Cyanogenmod.
